### PR TITLE
fixed STEP case for DatabaseIFC.ParseString

### DIFF
--- a/Core/IFC/DatabaseIFC.cs
+++ b/Core/IFC/DatabaseIFC.cs
@@ -325,19 +325,30 @@ namespace GeometryGym.Ifc
 				return null;
 
 			DatabaseIfc db = new DatabaseIfc(ModelView.Ifc4NotAssigned);
+			char startingChar = str[0];
+			switch (startingChar)
+			{
 #if (!NOIFCJSON)
-			if (str.StartsWith("{"))
-			{
-				JsonObject jobj = JsonObject.Parse(str) as JsonObject;
-				if (str != null)
-					db.ReadJSON(jobj);
-			}
+				case '{':
+					{
+						JsonObject jobj = JsonObject.Parse(str) as JsonObject;
+						if (str != null)
+							db.ReadJSON(jobj);
+						break;
+					}
 #endif
-			if (str.StartsWith("<"))
-			{
-				System.Xml.XmlDocument doc = new System.Xml.XmlDocument();
-				doc.LoadXml(str);
-				db.ReadXMLDoc(doc);
+				case '<':
+					{
+						System.Xml.XmlDocument doc = new System.Xml.XmlDocument();
+						doc.LoadXml(str);
+						db.ReadXMLDoc(doc);
+						break;
+					}
+				default:
+					{
+						new SerializationIfcSTEP(db).importLines(str.Split('\n'));
+						break;
+					}
 			}
 			return db;
 		}


### PR DESCRIPTION
Hello!
I noticed that the current implementation of `public static DatabaseIfc ParseString(string str)` will return an empty database for  the STEP format, but in this awesome library, there are some internal methods that will take care of such cases.

So I propose this change, which is rather small, yet fixes method behavior.

I also made a quick test for this fix, to ensure what files get to be parsed equally from files and from ParseString:
[testcase](https://github.com/keepdream1ng/GeometryGymIFC/blob/testing/DLL%20Projects/GeometryGymIFC.Tests/DatabaseIFCTests.cs)