### PR TITLE
Add missing IfcTimeStamp parsing to parseSimpleValue

### DIFF
--- a/Core/IFC/ParserIFC.cs
+++ b/Core/IFC/ParserIFC.cs
@@ -378,7 +378,7 @@ namespace GeometryGym.Ifc
 			{
 				string valueString = str.Substring(13, str.Length - 14);
 				if (int.TryParse(valueString, out int ts))
-					return new IfcInteger(ts);
+					return new IfcTimeStamp(ts);
 			}
 			int i = 0;
 			if (int.TryParse(str, out i))

--- a/Core/IFC/ParserIFC.cs
+++ b/Core/IFC/ParserIFC.cs
@@ -374,6 +374,12 @@ namespace GeometryGym.Ifc
 			}
 			if(str.StartsWith("IFCDURATION("))
 				return IfcDuration.Convert(str.Substring(13, str.Length - 15));
+			if (str.StartsWith("IFCTIMESTAMP("))
+			{
+				string valueString = str.Substring(13, str.Length - 14);
+				if (int.TryParse(valueString, out int ts))
+					return new IfcInteger(ts);
+			}
 			int i = 0;
 			if (int.TryParse(str, out i))
 				return new IfcInteger(i);


### PR DESCRIPTION
Hi! 
While working with the library, I noticed that `IfcTimeStamp` was completely missing from `ParserIFC.parseSimpleValue`, causing those values not to be read. 

I just added the specific block to parse `IFCTIMESTAMP` and extract the integer correctly. Just a small addition, hope it helps!